### PR TITLE
Implement flashcard study features

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,54 +5,237 @@
 <title>闪卡学习</title>
 <style>
 *{box-sizing:border-box;margin:0;padding:0;}
-body{font-family:'Segoe UI',Arial,sans-serif;background:#f0f2f5;color:#333;}
-header{padding:20px;text-align:center;}
+body{font-family:'Segoe UI',Arial,sans-serif;background:#f0f2f5;color:#333;display:flex;min-height:100vh;}
+header{padding:20px;text-align:center;background:#fff;border-bottom:1px solid #e5e7eb;}
 header h1{font-size:28px;}
-.controls{display:flex;justify-content:space-between;align-items:center;padding:20px;max-width:800px;margin:0 auto;}
-.controls input[type="text"]{flex:1;padding:10px;border-radius:8px;border:1px solid #ccc;margin-right:10px;}
-.controls button{padding:10px 16px;border:none;border-radius:8px;background:#6366f1;color:#fff;cursor:pointer;}
-.controls button:hover{background:#4f46e5;}
-.card-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:20px;padding:0 20px 40px;max-width:1000px;margin:0 auto;}
+#sidebar{width:200px;background:#fff;border-right:1px solid #e5e7eb;padding:20px;overflow-y:auto;}
+#sidebar h2{font-size:18px;margin:10px 0;}
+#sidebar ul{list-style:none;}
+#sidebar li{padding:4px 0;cursor:pointer;}
+#content{flex:1;display:flex;flex-direction:column;}
+.topbar{display:flex;justify-content:space-between;align-items:center;padding:10px 20px;gap:10px;}
+.topbar input[type="text"]{flex:1;padding:8px;border-radius:6px;border:1px solid #ccc;}
+.topbar button{padding:8px 12px;border:none;border-radius:6px;background:#6366f1;color:#fff;cursor:pointer;}
+.topbar button:hover{background:#4f46e5;}
+.progress{display:flex;gap:10px;padding:10px 20px;font-size:14px;}
+.card-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:20px;padding:0 20px 40px;}
 .card{perspective:1000px;}
-.card-inner{position:relative;width:100%;height:180px;transform-style:preserve-3d;transition:transform 0.6s;cursor:pointer;}
+.card-inner{position:relative;width:100%;height:220px;transform-style:preserve-3d;transition:transform 0.6s;cursor:pointer;}
 .card.flip .card-inner{transform:rotateY(180deg);}
-.card-face{position:absolute;width:100%;height:100%;backface-visibility:hidden;border-radius:12px;padding:20px;display:flex;align-items:center;justify-content:center;font-size:16px;}
+.card-face{position:absolute;width:100%;height:100%;backface-visibility:hidden;border-radius:12px;padding:20px;display:flex;align-items:center;justify-content:center;font-size:14px;}
 .card-front{background:#fff;border:1px solid #e5e7eb;}
-.card-back{background:linear-gradient(135deg,#6366f1,#3b82f6);color:#fff;transform:rotateY(180deg);}
-#addModal{display:none;position:fixed;inset:0;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;}
-#addModal .modal-content{background:#fff;border-radius:12px;padding:20px;width:300px;display:flex;flex-direction:column;gap:10px;}
+.card-back{background:linear-gradient(135deg,#6366f1,#3b82f6);color:#fff;transform:rotateY(180deg);flex-direction:column;}
+.rating{margin-top:10px;display:flex;gap:6px;}
+.rating button{flex:1;padding:6px 8px;border:none;border-radius:6px;color:#fff;cursor:pointer;}
+.rating .easy{background:#16a34a;}
+.rating .medium{background:#f59e0b;}
+.rating .hard{background:#dc2626;}
+#addModal{display:none;position:fixed;inset:0;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;z-index:20;}
+#addModal .modal-content{background:#fff;border-radius:12px;padding:20px;width:320px;display:flex;flex-direction:column;gap:10px;}
 #addModal input,#addModal textarea{width:100%;padding:8px;border:1px solid #ccc;border-radius:8px;}
 #addModal button{padding:8px 12px;border:none;border-radius:8px;cursor:pointer;}
 #addModal .close-btn{align-self:flex-end;background:#e5e7eb;}
 #addModal .save-btn{background:#6366f1;color:#fff;}
+.notes{padding:10px 20px;}
+.notes textarea{width:100%;height:80px;padding:8px;border:1px solid #ccc;border-radius:8px;}
+.notes button{margin-top:6px;padding:6px 12px;border:none;border-radius:6px;background:#6366f1;color:#fff;}
+.notes ul{margin-top:10px;list-style:none;}
+.notes li{background:#fff;border:1px solid #e5e7eb;padding:6px;border-radius:6px;margin-bottom:4px;font-size:14px;}
+@media (max-width:600px){#sidebar{position:fixed;left:-200px;top:0;height:100%;transition:left .3s;}#sidebar.open{left:0;}body.menu-open{overflow:hidden;}}
 </style>
 </head>
 <body>
-<header>
-<h1>闪卡学习</h1>
-</header>
-<div class="controls">
-<input type="text" id="search" placeholder="搜索卡片…" oninput="renderCards(this.value)">
-<button onclick="openAddModal()">新建卡片</button>
+<div id="sidebar">
+  <h2>科目</h2>
+  <ul id="subjectList"></ul>
 </div>
-<div class="card-grid" id="card-grid"></div>
+<div id="content">
+  <header>
+    <h1>闪卡学习</h1>
+  </header>
+  <div class="topbar">
+    <input type="text" id="search" placeholder="搜索卡片…" oninput="renderCards()">
+    <button onclick="toggleSidebar()">分类</button>
+    <button onclick="openAddModal()">新建卡片</button>
+    <button onclick="openImportModal()">导入JSON</button>
+  </div>
+  <div class="progress" id="progress"></div>
+  <div class="card-grid" id="card-grid"></div>
+  <div class="notes">
+    <textarea id="noteText" placeholder="快速笔记..."></textarea>
+    <button onclick="addNote()">保存笔记</button>
+    <ul id="noteList"></ul>
+  </div>
+</div>
 <div id="addModal">
-<div class="modal-content">
-<button class="close-btn" onclick="closeAddModal()">关闭</button>
-<input type="text" id="newFront" placeholder="正面内容">
-<textarea id="newBack" rows="4" placeholder="反面内容"></textarea>
-<button class="save-btn" onclick="addCard()">保存</button>
+  <div class="modal-content">
+    <button class="close-btn" onclick="closeAddModal()">关闭</button>
+    <input type="text" id="newSubject" placeholder="科目">
+    <input type="text" id="newChapter" placeholder="章节">
+    <input type="text" id="newFront" placeholder="正面内容">
+    <textarea id="newBack" rows="4" placeholder="反面内容"></textarea>
+    <button class="save-btn" onclick="addCard()">保存</button>
+  </div>
 </div>
+<div id="importModal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;z-index:20;">
+  <div class="modal-content" style="width:320px;">
+    <button class="close-btn" onclick="closeImportModal()">关闭</button>
+    <textarea id="importArea" rows="8" placeholder='[{"subject":"","chapter":"","front":"","back":""}]'></textarea>
+    <button class="save-btn" onclick="importCards()">导入</button>
+  </div>
 </div>
 <script>
-let cards=JSON.parse(localStorage.getItem('cards')||'[]');
-function save(){localStorage.setItem('cards',JSON.stringify(cards));}
-function renderCards(filter=''){const grid=document.getElementById('card-grid');grid.innerHTML='';const filtered=cards.filter(c=>c.front.includes(filter)||c.back.includes(filter));filtered.forEach((c,index)=>{const card=document.createElement('div');card.className='card';card.innerHTML=`<div class="card-inner" onclick="flipCard(event)"><div class="card-face card-front">${c.front}</div><div class="card-face card-back">${c.back}</div></div>`;card.dataset.index=index;grid.appendChild(card);});}
-function flipCard(e){const card=e.currentTarget.parentElement;card.classList.toggle('flip');}
+const data = JSON.parse(localStorage.getItem('study-data') || '{"cards":[],"notes":[]}');
+let {cards, notes} = data;
+let currentSubject = '';
+let currentChapter = '';
+
+function save(){
+  localStorage.setItem('study-data', JSON.stringify({cards, notes}));
+}
+
+function renderSidebar(){
+  const ul = document.getElementById('subjectList');
+  ul.innerHTML='';
+  const map = {};
+  cards.forEach(c=>{if(!map[c.subject]) map[c.subject]=new Set(); map[c.subject].add(c.chapter);});
+  Object.keys(map).forEach(sub=>{
+    const li=document.createElement('li');
+    li.textContent=sub||'未分类';
+    li.onclick=()=>{currentSubject=sub;currentChapter='';renderSidebar();renderCards();};
+    if(sub===currentSubject){
+      const ulCh=document.createElement('ul');
+      map[sub].forEach(ch=>{
+        const liCh=document.createElement('li');
+        liCh.style.marginLeft='10px';
+        liCh.textContent=ch||'默认';
+        liCh.onclick=(e)=>{e.stopPropagation();currentSubject=sub;currentChapter=ch;renderCards();};
+        ulCh.appendChild(liCh);
+      });
+      li.appendChild(ulCh);
+    }
+    ul.appendChild(li);
+  });
+}
+
+function cardDue(c){return !c.due || c.due <= Date.now();}
+
+function renderCards(){
+  const grid=document.getElementById('card-grid');
+  grid.innerHTML='';
+  const search=document.getElementById('search').value.trim();
+  const filtered=cards.filter(c=>{
+    if(currentSubject && c.subject!==currentSubject) return false;
+    if(currentChapter && c.chapter!==currentChapter) return false;
+    if(search && !c.front.includes(search) && !c.back.includes(search)) return false;
+    return cardDue(c);
+  });
+  filtered.forEach((c,index)=>{
+    const div=document.createElement('div');
+    div.className='card';
+    div.innerHTML=`<div class="card-inner" onclick="flipCard(event)">
+      <div class="card-face card-front">${c.front}</div>
+      <div class="card-face card-back">${c.back}
+        <div class="rating">
+          <button class="hard" onclick="rateCard(${index},0,event)">困难</button>
+          <button class="medium" onclick="rateCard(${index},3,event)">模糊</button>
+          <button class="easy" onclick="rateCard(${index},5,event)">清晰</button>
+        </div>
+      </div></div>`;
+    grid.appendChild(div);
+  });
+  updateProgress();
+}
+
+function flipCard(e){e.currentTarget.parentElement.classList.toggle('flip');}
+
+function rateCard(idx, grade, ev){
+  ev.stopPropagation();
+  const c=cards[idx];
+  c.repetitions=c.repetitions||0;
+  c.interval=c.interval||0;
+  c.EF=c.EF||2.5;
+  if(grade>=3){
+    if(c.repetitions===0)c.interval=1;else if(c.repetitions===1)c.interval=6;else c.interval=Math.round(c.interval*c.EF);
+    c.EF=c.EF+(0.1-(5-grade)*(0.08+(5-grade)*0.02));
+    if(c.EF<1.3)c.EF=1.3;
+    c.repetitions++;
+  }else{
+    c.repetitions=0;
+    c.interval=1;
+  }
+  c.due=Date.now()+c.interval*86400000;
+  save();
+  renderCards();
+}
+
+function addCard(){
+  const subject=document.getElementById('newSubject').value.trim();
+  const chapter=document.getElementById('newChapter').value.trim();
+  const front=document.getElementById('newFront').value.trim();
+  const back=document.getElementById('newBack').value.trim();
+  if(!front||!back) return;
+  cards.push({subject,chapter,front,back,repetitions:0,interval:0,EF:2.5,due:Date.now()});
+  save();
+  closeAddModal();
+  renderSidebar();
+  renderCards();
+  document.getElementById('newSubject').value='';
+  document.getElementById('newChapter').value='';
+  document.getElementById('newFront').value='';
+  document.getElementById('newBack').value='';
+}
+
+function addNote(){
+  const text=document.getElementById('noteText').value.trim();
+  if(!text) return;
+  notes.push({text,date:Date.now()});
+  document.getElementById('noteText').value='';
+  save();
+  renderNotes();
+}
+
+function renderNotes(){
+  const ul=document.getElementById('noteList');
+  ul.innerHTML='';
+  notes.forEach(n=>{
+    const li=document.createElement('li');
+    li.textContent=`${new Date(n.date).toLocaleDateString()} ${n.text}`;
+    ul.appendChild(li);
+  });
+}
+
 function openAddModal(){document.getElementById('addModal').style.display='flex';}
 function closeAddModal(){document.getElementById('addModal').style.display='none';}
-function addCard(){const front=document.getElementById('newFront').value.trim();const back=document.getElementById('newBack').value.trim();if(!front||!back)return;cards.push({front,back});save();renderCards();document.getElementById('newFront').value='';document.getElementById('newBack').value='';closeAddModal();}
+function openImportModal(){document.getElementById('importModal').style.display='flex';}
+function closeImportModal(){document.getElementById('importModal').style.display='none';}
+
+function importCards(){
+  try{
+    const arr=JSON.parse(document.getElementById('importArea').value||'[]');
+    arr.forEach(o=>cards.push({subject:o.subject||'',chapter:o.chapter||'',front:o.front,back:o.back,repetitions:0,interval:0,EF:2.5,due:Date.now()}));
+    save();
+    renderSidebar();
+    renderCards();
+    document.getElementById('importArea').value='';
+    closeImportModal();
+  }catch(e){alert('格式错误');}
+}
+
+function updateProgress(){
+  const total=cards.length;
+  const due=cards.filter(cardDue).length;
+  const learned=cards.filter(c=>c.repetitions>0).length;
+  document.getElementById('progress').textContent=`总计 ${total} 张卡，待复习 ${due}，已学习 ${learned}`;
+}
+
+function toggleSidebar(){
+  document.getElementById('sidebar').classList.toggle('open');
+}
+
+renderSidebar();
 renderCards();
+renderNotes();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- revamp page layout with sidebar navigation, progress display, and notes
- add card creation modal with subject/chapter fields and JSON import modal
- implement spaced-repetition scheduling and progress tracking in localStorage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68728f6bbbbc832b8f5216de853c3274