### PR TITLE
Improve card demo layout

### DIFF
--- a/card-demo.html
+++ b/card-demo.html
@@ -13,7 +13,7 @@
     body { font-family: 'Roboto Slab', serif; }
   </style>
 </head>
-<body class="bg-gray-100 min-h-screen flex items-center justify-center p-4">
+<body class="bg-gray-100 min-h-screen flex items-center justify-center p-4 sm:p-10">
   <div id="root" class="w-full max-w-md"></div>
 
   <script type="text/javascript">
@@ -23,40 +23,40 @@
     function KnowledgeCard() {
       const [open, setOpen] = useState(false);
       return (
-        React.createElement('div', { className: 'bg-white rounded-lg shadow-lg p-6 space-y-4 cursor-pointer', onClick: () => setOpen(!open) },
-          React.createElement('h2', { className: 'text-lg font-bold text-gray-800 flex items-center space-x-2' },
+        React.createElement('div', { className: 'bg-white rounded-lg shadow-lg p-6 sm:p-8 space-y-4 cursor-pointer transition-all flex flex-col', onClick: () => setOpen(!open) },
+          React.createElement('h2', { className: 'text-lg sm:text-xl font-bold text-gray-800 flex items-center space-x-2' },
             React.createElement(BookOpen, { className: 'text-green-600 w-5 h-5' }),
             React.createElement('span', null, '知识点名称')
           ),
-          React.createElement('div', { className: 'flex space-x-2 text-sm text-green-600' },
+          React.createElement('div', { className: 'flex space-x-2 text-sm sm:text-base text-green-600' },
             React.createElement(Tag, { className: 'w-4 h-4' }),
             React.createElement('span', null, '关键词')
           ),
-          React.createElement('p', { className: 'text-sm text-gray-500' }, '一句话作用目的总结'),
-          open && React.createElement('div', { className: 'space-y-2 text-sm text-gray-700' },
+          React.createElement('p', { className: 'text-sm sm:text-base text-gray-500' }, '一句话作用目的总结'),
+          open && React.createElement('div', { className: 'space-y-2 text-sm sm:text-base text-gray-700' },
             React.createElement('div', null,
-              React.createElement('h3', { className: 'font-semibold text-gray-800 flex items-center space-x-1' },
+              React.createElement('h3', { className: 'font-semibold text-gray-800 flex items-center space-x-1 text-sm sm:text-base' },
                 React.createElement(ChevronRight, { className: 'w-4 h-4 text-green-600' }),
                 React.createElement('span', null, '渐进式原理说明')
               ),
               React.createElement('p', null, '详细描述')
             ),
             React.createElement('div', null,
-              React.createElement('h3', { className: 'font-semibold text-gray-800 flex items-center space-x-1' },
+              React.createElement('h3', { className: 'font-semibold text-gray-800 flex items-center space-x-1 text-sm sm:text-base' },
                 React.createElement(ChevronRight, { className: 'w-4 h-4 text-green-600' }),
                 React.createElement('span', null, '相关场景')
               ),
               React.createElement('p', null, '场景标题')
             ),
             React.createElement('div', null,
-              React.createElement('h3', { className: 'font-semibold text-gray-800 flex items-center space-x-1' },
+              React.createElement('h3', { className: 'font-semibold text-gray-800 flex items-center space-x-1 text-sm sm:text-base' },
                 React.createElement(ChevronRight, { className: 'w-4 h-4 text-green-600' }),
                 React.createElement('span', null, '举例说明')
               ),
               React.createElement('p', null, '实际案例')
             ),
             React.createElement('div', { className: 'bg-gray-50 p-3 rounded' },
-              React.createElement('h3', { className: 'font-semibold text-gray-800 flex items-center space-x-1' },
+              React.createElement('h3', { className: 'font-semibold text-gray-800 flex items-center space-x-1 text-sm sm:text-base' },
                 React.createElement(ArrowRightCircle, { className: 'w-4 h-4 text-green-600' }),
                 React.createElement('span', null, '练习题目')
               ),


### PR DESCRIPTION
## Summary
- refine React-based knowledge card example
- add responsive padding and text sizes
- ensure Lucide icons and fonts remain in use

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68733de1a128832b988273627c071201