### PR TITLE
Fix tag icon markup that broke scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,8 +438,8 @@ function renderGrid(showCards = currentCardList) {
         <div class="flashcard-front">
           <div class="card-title">${card.front}</div>
           <div class="flashcard-tags">
-            ${card.examFrequency === '高频' ? '<span class="tag high"><span class='tag-icon'>⭐</span>高频</span>' : ''}
-            ${card.level === '重点' ? '<span class="tag medium"><span class='tag-icon'>📌</span>重点</span>' : ''}
+            ${card.examFrequency === '高频' ? '<span class="tag high"><span class="tag-icon">⭐</span>高频</span>' : ''}
+            ${card.level === '重点' ? '<span class="tag medium"><span class="tag-icon">📌</span>重点</span>' : ''}
           </div>
           <div class="card-clue">${card.clue || ''}</div>
           <div class="card-content"><span>${card.context || ''}</span></div>
@@ -822,8 +822,8 @@ renderGrid = function(showCards=currentCardList) {
           </div>
           <div class="card-title">${card.front}</div>
           <div class="flashcard-tags">
-            ${card.examFrequency === '高频' ? '<span class="tag high"><span class='tag-icon'>⭐</span>高频</span>' : ''}
-            ${card.level === '重点' ? '<span class="tag medium"><span class='tag-icon'>📌</span>重点</span>' : ''}
+            ${card.examFrequency === '高频' ? '<span class="tag high"><span class="tag-icon">⭐</span>高频</span>' : ''}
+            ${card.level === '重点' ? '<span class="tag medium"><span class="tag-icon">📌</span>重点</span>' : ''}
           </div>
           <div class="card-clue">${card.clue || ''}</div>
           <div class="card-content"><span>${card.context || ''}</span></div>


### PR DESCRIPTION
## Summary
- fix quoting for `tag-icon` spans so JS renders correctly

## Testing
- `node -e "require('fs').readFileSync('index.html','utf8').match(/<script>([\s\S]*?)<\/script>/g).forEach(s=>{try{new Function(s.replace(/<script>|<\/script>/g,''));console.log('ok');}catch(e){console.error(e.message);}})"`

------
https://chatgpt.com/codex/tasks/task_e_68734d49203c832ba0813df20acfabd1