### PR TITLE
Improve flashcard card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,10 +36,11 @@
     .tools-section { align-self: start; }
     .flashcard-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 30px;
-      align-items: center;
-      justify-items: center;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      grid-auto-rows: max-content;
+      gap: 36px;
+      align-items: stretch;
+      justify-items: stretch;
       padding-bottom: 40px;
       min-height: 100vh;
     }
@@ -48,15 +49,15 @@
       width: 100%;
       max-width: 26rem;
       min-height: 260px;
-      max-height: 380px;
+      max-height: 60vh;
       perspective: 1200px;
       background: transparent;
       margin: 0 auto;
       position: relative;
       cursor: pointer;
       user-select: none;
-      border-radius: 14px;
-      box-shadow: 0 6px 28px rgba(100,120,180,0.12);
+      border-radius: 16px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.08);
       transition: box-shadow .24s, transform .24s;
     }
     .flashcard-inner {
@@ -76,26 +77,27 @@
       left: 0; top: 0;
       backface-visibility: hidden;
       background: #fff;
-      border-radius: 14px;
-      box-shadow: 0 1px 8px #2433560d;
+      border-radius: 16px;
+      box-shadow: 0 1px 6px rgba(36,51,86,0.08);
       display: flex;
       flex-direction: column;
-      justify-content: center;
+      justify-content: flex-start;
       cursor: pointer;
-      padding: 24px;
+      padding: 28px;
       transition: box-shadow .2s;
       z-index: 2;
-      overflow: auto;
+      overflow-y: auto;
+      max-height: 60vh;
     }
     .flashcard-front { z-index: 3; }
     .flashcard-back {
-      background: linear-gradient(140deg, #f1fdf4 70%, #d1fae5 100%);
+      background: linear-gradient(140deg, #f1fdf4 70%, #e7f9ed 100%);
       transform: rotateY(180deg);
       z-index: 1;
-      border: 2.5px solid #bbf7d0;
+      border: 1.5px solid #bbf7d0;
     }
     .flashcard:hover {
-      box-shadow: 0 12px 32px rgba(100,120,180,0.18);
+      box-shadow: 0 8px 26px rgba(0,0,0,0.15);
       transform: translateY(-6px);
     }
     .card-title {font-size:1.23em;font-weight:700;margin-bottom:9px;}


### PR DESCRIPTION
## Summary
- make grid auto rows and wider min column width
- soften card style and add scrollbars when content gets tall
- refine hover effect and padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687351228384832bb09e009cb1f03ea4