### PR TITLE
Improve flashcard layout and filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,13 @@
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
       grid-auto-rows: max-content;
-      gap: 36px;
+      gap: 48px;
       align-items: stretch;
       justify-items: stretch;
+      padding: 30px;
       padding-bottom: 40px;
-      min-height: 100vh;
+      max-height: 92vh;
+      overflow-y: auto;
     }
     /* ---- 3D闪卡动画样式 ---- */
     .flashcard {
@@ -236,14 +238,14 @@
     .note-actions {display: flex;justify-content: space-between;margin-top: 10px;padding-top: 12px;border-top: 1px solid #e2e8f0;}
     /* 响应式适配 */
   @media (max-width:1200px) {
-        .container {grid-template-columns: 1fr 1fr;gap: 13px;}
+        .container {grid-template-columns: 1fr 1fr;gap: 16px;}
         .sidebar, .tools-section {min-height: 410px;}
-        .flashcard-grid {grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));}
+        .flashcard-grid {grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 32px; padding: 20px;}
       }
       @media (max-width:900px) {
-        .container {grid-template-columns: 1fr;gap:7px;padding:8px;}
+        .container {grid-template-columns: 1fr;gap:10px;padding:8px;}
         .sidebar, .tools-section {position: static;min-height: auto;margin-bottom:12px;}
-        .flashcard-grid {grid-template-columns: 1fr;}
+        .flashcard-grid {grid-template-columns: 1fr; gap: 24px; padding: 15px;}
       }
     /* 导入弹窗样式 */
     #import-modal-root>div {
@@ -407,13 +409,23 @@ function updateCardList() {
   }, {});
   const list = document.getElementById('card-list');
   list.innerHTML = '';
+  const allItem = document.createElement('div');
+  allItem.className = 'chapter-item';
+  allItem.textContent = '全部卡片';
+  allItem.onclick = () => { currentCardList = cards; renderGrid(currentCardList); };
+  list.appendChild(allItem);
   for (let cat in grouped) {
     const catDiv = document.createElement('div');
     catDiv.className = 'category-item';
     const catHeader = document.createElement('div');
     catHeader.className = 'category-header';
     catHeader.innerHTML = `<i>▶</i>${cat}`;
-    catHeader.onclick = () => { catHeader.classList.toggle('expanded'); catContent.classList.toggle('expanded'); };
+    catHeader.onclick = () => {
+      catHeader.classList.toggle('expanded');
+      catContent.classList.toggle('expanded');
+      currentCardList = Object.values(grouped[cat]).flat();
+      renderGrid(currentCardList);
+    };
     const catContent = document.createElement('div');
     catContent.className = 'category-content';
     for (let chap in grouped[cat]) {


### PR DESCRIPTION
## Summary
- enlarge spacing between flashcards and add internal padding
- allow scrolling in the flashcard area
- tweak responsive gaps
- filter cards by category or chapter from the sidebar and add an "all cards" item

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687353c0cdc8832bb736c5bc48ca2c38