### PR TITLE
Enhance flashcard UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,12 +36,12 @@
     .tools-section { align-self: start; }
     .flashcard-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       grid-auto-rows: max-content;
-      gap: 48px;
+      gap: 28px;
       align-items: stretch;
       justify-items: stretch;
-      padding: 30px;
+      padding: 20px;
       padding-bottom: 40px;
       max-height: 92vh;
       overflow-y: auto;
@@ -102,6 +102,29 @@
       box-shadow: 0 8px 26px rgba(0,0,0,0.15);
       transform: translateY(-6px);
     }
+    /* 缩略图卡片 */
+    .flashcard-thumb {
+      background:#fff;
+      border-radius:12px;
+      padding:18px;
+      min-height:120px;
+      box-shadow:0 2px 12px rgba(0,0,0,0.05);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      text-align:center;
+      cursor:pointer;
+      overflow:hidden;
+      transition:transform .2s;
+    }
+    .flashcard-thumb:hover {transform:scale(1.05);}
+    .flashcard-thumb .thumb-title {font-weight:600;color:#334155;font-size:1.05em;}
+
+    /* 大卡片模态 */
+    #card-modal {position:fixed;left:0;top:0;right:0;bottom:0;background:rgba(0,0,0,0.4);display:none;align-items:center;justify-content:center;z-index:1500;}
+    #card-modal.active {display:flex;}
+    #card-modal .flashcard {max-width:480px;width:90%;}
+    #card-modal .close-btn {position:absolute;right:12px;top:12px;background:#f8fafc;border:none;border-radius:50%;width:32px;height:32px;font-size:18px;cursor:pointer;}
     .card-title {font-size:1.23em;font-weight:700;margin-bottom:9px;}
     .flashcard-tags {margin-bottom: 10px;}
     .tag {display:inline-block;font-size:12px;border-radius:10px;padding:2px 9px 2px 7px;margin-right:6px;}
@@ -240,12 +263,12 @@
   @media (max-width:1200px) {
         .container {grid-template-columns: 1fr 1fr;gap: 16px;}
         .sidebar, .tools-section {min-height: 410px;}
-        .flashcard-grid {grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 32px; padding: 20px;}
+        .flashcard-grid {grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 24px; padding: 20px;}
       }
       @media (max-width:900px) {
         .container {grid-template-columns: 1fr;gap:10px;padding:8px;}
         .sidebar, .tools-section {position: static;min-height: auto;margin-bottom:12px;}
-        .flashcard-grid {grid-template-columns: 1fr; gap: 24px; padding: 15px;}
+        .flashcard-grid {grid-template-columns: 1fr; gap: 20px; padding: 15px;}
       }
     /* 导入弹窗样式 */
     #import-modal-root>div {
@@ -280,6 +303,7 @@
     </div>
     <!-- 主卡片区 -->
     <div class="flashcard-grid" id="flashcard-grid"></div>
+    <div id="card-modal" onclick="closeCardModal(event)"></div>
     <!-- 工具栏 -->
     <div class="tools-section">
       <div class="tool-card countdown">
@@ -510,6 +534,59 @@ function formatCardContent(content) {
     return html;
   }
   return `<p>${mainContent.replace(/\n/g, '<br>')}</p>${notes ? `<div class="note">${notes}</div>` : ''}`;
+}
+
+function truncateText(t,len=15){
+  return t.length>len? t.slice(0,len)+'…': t;
+}
+
+function openCard(front){
+  const card = cards.find(c=>c.front===front);
+  if(!card) return;
+  const modal = document.getElementById('card-modal');
+  modal.innerHTML = `
+    <div class="flashcard">
+      <button class="close-btn" onclick="closeCardModal(event)">×</button>
+      <div class="flashcard-inner">
+        <div class="flashcard-front">
+          <div style="position:absolute;top:13px;right:16px;z-index:4;">
+            <button title="编辑" onclick="event.stopPropagation();showEditCard('${card.front}')" style="border:none;background:none;font-size:18px;cursor:pointer;">✏️</button>
+          </div>
+          <div class="card-title">${card.front}</div>
+          <div class="flashcard-tags">
+            ${card.examFrequency === '高频' ? '<span class="tag high"><span class="tag-icon">⭐</span>高频</span>' : ''}
+            ${card.level === '重点' ? '<span class="tag medium"><span class="tag-icon">📌</span>重点</span>' : ''}
+          </div>
+          <div class="card-clue">${card.clue || ''}</div>
+          <div class="card-content"><span>${card.context || ''}</span></div>
+        </div>
+        <div class="flashcard-back">
+          <div class="card-category">${card.category} > ${card.chapter}</div>
+          <div class="card-content">${formatCardContent(card.back)}</div>
+          <div class="card-footer">
+            <div class="mastery-buttons">
+              <button class="mastery-btn hard" onclick="updateMastery('${card.front}', 1, event)"><span>😅</span>困难</button>
+              <button class="mastery-btn medium" onclick="updateMastery('${card.front}', 3, event)"><span>🤔</span>模糊</button>
+              <button class="mastery-btn easy" onclick="updateMastery('${card.front}', 5, event)"><span>✨</span>清晰</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>`;
+  const fc = modal.querySelector('.flashcard');
+  fc.onclick = function(e){
+    if(e.target.tagName==='BUTTON' || e.target.classList.contains('mastery-btn')) return;
+    this.classList.toggle('flipped');
+  };
+  modal.classList.add('active');
+  modal.onclick = closeCardModal;
+}
+
+function closeCardModal(e){
+  if(e) e.stopPropagation();
+  const modal = document.getElementById('card-modal');
+  modal.classList.remove('active');
+  modal.innerHTML = '';
 }
 
 // ============ 搜索过滤 ============
@@ -825,45 +902,15 @@ function deleteCard(front) {
   closeModal();
 }
 
-// 给每张卡片添加右上角编辑按钮（和主卡片区渲染结合）
-const oldRenderGrid = renderGrid;
+// 重绘卡片墙及编辑
 renderGrid = function(showCards=currentCardList) {
   const grid = document.getElementById('flashcard-grid');
   grid.innerHTML = '';
   showCards.forEach(card => {
     const div = document.createElement('div');
-    div.className = 'flashcard';
-    div.innerHTML = `
-      <div class="flashcard-inner">
-        <div class="flashcard-front">
-          <div style="position:absolute;top:13px;right:16px;z-index:4;">
-            <button title="编辑" onclick="event.stopPropagation();showEditCard('${card.front}')" style="border:none;background:none;font-size:18px;cursor:pointer;">✏️</button>
-          </div>
-          <div class="card-title">${card.front}</div>
-          <div class="flashcard-tags">
-            ${card.examFrequency === '高频' ? '<span class="tag high"><span class="tag-icon">⭐</span>高频</span>' : ''}
-            ${card.level === '重点' ? '<span class="tag medium"><span class="tag-icon">📌</span>重点</span>' : ''}
-          </div>
-          <div class="card-clue">${card.clue || ''}</div>
-          <div class="card-content"><span>${card.context || ''}</span></div>
-        </div>
-        <div class="flashcard-back">
-          <div class="card-category">${card.category} > ${card.chapter}</div>
-          <div class="card-content">${formatCardContent(card.back)}</div>
-          <div class="card-footer">
-            <div class="mastery-buttons">
-              <button class="mastery-btn hard" onclick="updateMastery('${card.front}', 1, event)"><span>😅</span>困难</button>
-              <button class="mastery-btn medium" onclick="updateMastery('${card.front}', 3, event)"><span>🤔</span>模糊</button>
-              <button class="mastery-btn easy" onclick="updateMastery('${card.front}', 5, event)"><span>✨</span>清晰</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    `;
-    div.onclick = function(e) {
-      if (e.target.tagName === 'BUTTON' || e.target.classList.contains('mastery-btn')) return;
-      this.classList.toggle('flipped');
-    };
+    div.className = 'flashcard-thumb';
+    div.innerHTML = `<div class="thumb-title">${truncateText(card.front)}</div>`;
+    div.onclick = () => openCard(card.front);
     grid.appendChild(div);
   });
 };


### PR DESCRIPTION
## Summary
- redesign card grid to show compact thumbnails
- add modal view for answering a single card
- implement hover animations and responsive layout

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68735da06d50832ba5af13a3ab915519